### PR TITLE
Update action.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: CSharpier Linter
-        uses: guibranco/github-csharpier-linter-action@v1.0.4
+        uses: guibranco/github-csharpier-linter-action@v1.0.5
 ```
 
 ## ⚡ Requirements
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: CSharpier Linter
-        uses: guibranco/github-csharpier-linter-action@v1.0.4
+        uses: guibranco/github-csharpier-linter-action@v1.0.5
 ```
 
 ## 🔧 How It Works

--- a/action.yml
+++ b/action.yml
@@ -122,5 +122,6 @@ runs:
 
     - name: Fail if formatting issues are found
       if: env.issues_detected == 'true'
+      shell: bash
       run: exit 1
 

--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ runs:
       run: |
         set -e
 
-        output=$(dotnet csharpier check . || true)
+        output=$(dotnet csharpier check . 2>&1 || true)
         echo "$output" > csharpier-output.txt
 
         echo "$output"
@@ -75,7 +75,6 @@ runs:
         current_file=""
         current_line="1"
 
-        # Create a temp file for the summary
         summary_file="csharpier-summary.md"
         echo "## 🔥 Formatting issues detected" > "$summary_file"
         echo "" >> "$summary_file"
@@ -102,7 +101,6 @@ runs:
         echo "⚡ Please run \`dotnet csharpier .\` locally to fix the formatting issues." >> "$summary_file"
         cat "$summary_file" >> "$GITHUB_STEP_SUMMARY"
         echo "issues_detected=true" >> $GITHUB_ENV
-        exit 1
 
     - name: Find existing comment
       if: env.issues_detected == 'true'
@@ -121,3 +119,8 @@ runs:
         body-path: csharpier-summary.md
         edit-mode: replace
         comment-id: ${{ steps.find-comment.outputs.comment-id }}
+
+    - name: Fail if formatting issues are found
+      if: env.issues_detected == 'true'
+      run: exit 1
+


### PR DESCRIPTION
## 📑 Description
## Summary by Sourcery

Modify the CSharpier GitHub Action to post the summary comment before failing the workflow.

CI:
- Capture stderr output from the `dotnet csharpier check` command.
- Move the workflow failure logic to a separate step that runs after attempting to post the summary comment.
- Remove an internal comment from the workflow steps.

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the version tag for the GitHub Action in the README usage examples.

- **Chores**
  - Improved workflow error handling by separating the formatting check and job failure steps for clearer output and job status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->